### PR TITLE
fix(go-runner): implement `MatchString` testdep

### DIFF
--- a/example-codspeed/cli/runner.go
+++ b/example-codspeed/cli/runner.go
@@ -4,15 +4,46 @@
 package main
 
 import (
-	"fmt"
 	"io"
 	"reflect"
+	"regexp"
 	"time"
 
-	example "example"
-
 	codspeed_testing "github.com/CodSpeedHQ/codspeed-go/testing/testing"
+
+	// Import parent package containing the benchmarks
+	example "example"
 )
+
+// TestDeps is an implementation of the testing.testDeps interface,
+// suitable for passing to [testing.MainStart].
+//
+// It is partially copied from `testing/internal/testdeps/deps.go`, and
+// only implements the minimum required functionality.
+type TestDeps struct{}
+
+func (d TestDeps) ImportPath() string { return "" }
+
+var matchPat string
+var matchRe *regexp.Regexp
+
+func (TestDeps) MatchString(pat, str string) (result bool, err error) {
+	if matchRe == nil || matchPat != pat {
+		matchPat = pat
+		matchRe, err = regexp.Compile(matchPat)
+		if err != nil {
+			return
+		}
+	}
+	return matchRe.MatchString(str), nil
+}
+
+func (d TestDeps) SetPanicOnExit0(bool)                        {}
+func (d TestDeps) StartCPUProfile(io.Writer) error             { return nil }
+func (d TestDeps) StopCPUProfile()                             {}
+func (d TestDeps) StartTestLog(io.Writer)                      {}
+func (d TestDeps) StopTestLog() error                          { return nil }
+func (d TestDeps) WriteProfileTo(string, io.Writer, int) error { return nil }
 
 type corpusEntry = struct {
 	Parent     string
@@ -23,42 +54,19 @@ type corpusEntry = struct {
 	IsSeed     bool
 }
 
-type simpleDeps struct{}
-
-func (d simpleDeps) ImportPath() string                          { return "" }
-func (d simpleDeps) MatchString(pat, str string) (bool, error)   { return true, nil }
-func (d simpleDeps) SetPanicOnExit0(bool)                        {}
-func (d simpleDeps) StartCPUProfile(io.Writer) error             { return nil }
-func (d simpleDeps) StopCPUProfile()                             {}
-func (d simpleDeps) StartTestLog(io.Writer)                      {}
-func (d simpleDeps) StopTestLog() error                          { return nil }
-func (d simpleDeps) WriteProfileTo(string, io.Writer, int) error { return nil }
-
-func (d simpleDeps) CoordinateFuzzing(
-	fuzzTime time.Duration,
-	fuzzN int64,
-	minimizeTime time.Duration,
-	minimizeN int64,
-	parallel int,
-	corpus []corpusEntry,
-	types []reflect.Type,
-	corpusDir,
-	cacheDir string,
-) error {
+func (d TestDeps) CoordinateFuzzing(fuzzTime time.Duration, fuzzN int64, minimizeTime time.Duration, minimizeN int64, parallel int, corpus []corpusEntry, types []reflect.Type, corpusDir, cacheDir string) error {
 	return nil
 }
-func (d simpleDeps) RunFuzzWorker(fn func(corpusEntry) error) error {
-	return nil
-}
-func (d simpleDeps) ReadCorpus(dir string, types []reflect.Type) ([]corpusEntry, error) {
+func (d TestDeps) RunFuzzWorker(fn func(corpusEntry) error) error { return nil }
+func (d TestDeps) ReadCorpus(dir string, types []reflect.Type) ([]corpusEntry, error) {
 	return nil, nil
 }
-func (d simpleDeps) CheckCorpus(vals []any, types []reflect.Type) error {
+func (d TestDeps) CheckCorpus(vals []any, types []reflect.Type) error {
 	return nil
 }
-func (d simpleDeps) ResetCoverage()    {}
-func (d simpleDeps) SnapshotCoverage() {}
-func (d simpleDeps) InitRuntimeCoverage() (mode string, tearDown func(coverprofile string, gocoverdir string) (string, error), snapcov func() float64) {
+func (d TestDeps) ResetCoverage()    {}
+func (d TestDeps) SnapshotCoverage() {}
+func (d TestDeps) InitRuntimeCoverage() (mode string, tearDown func(coverprofile string, gocoverdir string) (string, error), snapcov func() float64) {
 	return "", nil, nil
 }
 
@@ -77,10 +85,6 @@ func main() {
 		},
 	}
 
-	for i := 0; i < len(benchmarks); i++ {
-		fmt.Printf("Benchmark %d: %s\n", i, benchmarks[i].Name)
-	}
-
-	m := codspeed_testing.MainStart(simpleDeps{}, tests, benchmarks, fuzzTargets, examples)
+	m := codspeed_testing.MainStart(TestDeps{}, tests, benchmarks, fuzzTargets, examples)
 	m.Run()
 }

--- a/go-runner/src/builder/template.go
+++ b/go-runner/src/builder/template.go
@@ -1,81 +1,84 @@
 package main
 
 import (
-    "io"
-    "time"
-    "reflect"
-    codspeed "github.com/CodSpeedHQ/codspeed-go/compat/testing"
-    codspeed_testing "github.com/CodSpeedHQ/codspeed-go/testing/testing"
+	"io"
+	"reflect"
+	"regexp"
+	"time"
 
-    // Import parent package containing the benchmarks
-{{#each benchmarks}}
-    {{import_alias}} "{{module_path}}"
-{{/each}}
+	codspeed_testing "github.com/CodSpeedHQ/codspeed-go/testing/testing"
+
+	// Import parent package containing the benchmarks
+	{{#each benchmarks}}
+	    {{import_alias}} "{{module_path}}"
+	{{/each}}
 )
 
-type BenchmarkEntry struct {
-    Name string
-    Func func(b *codspeed.B)
+// TestDeps is an implementation of the testing.testDeps interface,
+// suitable for passing to [testing.MainStart].
+//
+// It is partially copied from `testing/internal/testdeps/deps.go`, and
+// only implements the minimum required functionality.
+type TestDeps struct {}
+
+func (d TestDeps) ImportPath() string { return "" }
+
+var matchPat string
+var matchRe *regexp.Regexp
+
+func (TestDeps) MatchString(pat, str string) (result bool, err error) {
+	if matchRe == nil || matchPat != pat {
+		matchPat = pat
+		matchRe, err = regexp.Compile(matchPat)
+		if err != nil {
+			return
+		}
+	}
+	return matchRe.MatchString(str), nil
 }
+
+func (d TestDeps) SetPanicOnExit0(bool)                        {}
+func (d TestDeps) StartCPUProfile(io.Writer) error             { return nil }
+func (d TestDeps) StopCPUProfile()                             {}
+func (d TestDeps) StartTestLog(io.Writer)                      {}
+func (d TestDeps) StopTestLog() error                          { return nil }
+func (d TestDeps) WriteProfileTo(string, io.Writer, int) error { return nil }
 
 type corpusEntry = struct {
-    Parent     string
-    Path       string
-    Data       []byte
-    Values     []any
-    Generation int
-    IsSeed     bool
+	Parent     string
+	Path       string
+	Data       []byte
+	Values     []any
+	Generation int
+	IsSeed     bool
 }
 
-type simpleDeps struct{}
-
-func (d simpleDeps) ImportPath() string { return "" }
-func (d simpleDeps) MatchString(pat, str string) (bool, error) { return true, nil }
-func (d simpleDeps) SetPanicOnExit0(bool) {}
-func (d simpleDeps) StartCPUProfile(io.Writer) error { return nil }
-func (d simpleDeps) StopCPUProfile() {}
-func (d simpleDeps) StartTestLog(io.Writer) {}
-func (d simpleDeps) StopTestLog() error { return nil }
-func (d simpleDeps) WriteProfileTo(string, io.Writer, int) error { return nil }
-
-func (d simpleDeps) CoordinateFuzzing(
-    fuzzTime time.Duration,
-    fuzzN int64,
-    minimizeTime time.Duration,
-    minimizeN int64,
-    parallel int,
-    corpus []corpusEntry,
-    types []reflect.Type,
-    corpusDir,
-    cacheDir string,
-) error {
-    return nil
+func (d TestDeps) CoordinateFuzzing(fuzzTime time.Duration, fuzzN int64, minimizeTime time.Duration, minimizeN int64, parallel int, corpus []corpusEntry, types []reflect.Type, corpusDir, cacheDir string) error {
+	return nil
 }
-func (d simpleDeps) RunFuzzWorker(fn func(corpusEntry) error) error {
-    return nil
+func (d TestDeps) RunFuzzWorker(fn func(corpusEntry) error) error { return nil }
+func (d TestDeps) ReadCorpus(dir string, types []reflect.Type) ([]corpusEntry, error) {
+	return nil, nil
 }
-func (d simpleDeps) ReadCorpus(dir string, types []reflect.Type) ([]corpusEntry, error) {
-    return nil, nil
+func (d TestDeps) CheckCorpus(vals []any, types []reflect.Type) error {
+	return nil
 }
-func (d simpleDeps) CheckCorpus(vals []any, types []reflect.Type) error {
-    return nil
-}
-func (d simpleDeps) ResetCoverage() {}
-func (d simpleDeps) SnapshotCoverage() {}
-func (d simpleDeps) InitRuntimeCoverage() (mode string, tearDown func(coverprofile string, gocoverdir string) (string, error), snapcov func() float64) {
-    return "", nil, nil
+func (d TestDeps) ResetCoverage()    {}
+func (d TestDeps) SnapshotCoverage() {}
+func (d TestDeps) InitRuntimeCoverage() (mode string, tearDown func(coverprofile string, gocoverdir string) (string, error), snapcov func() float64) {
+	return "", nil, nil
 }
 
 func main() {
-    var tests = []codspeed_testing.InternalTest{}
-    var fuzzTargets = []codspeed_testing.InternalFuzzTarget{}
-    var examples = []codspeed_testing.InternalExample{}
-    var benchmarks = []codspeed_testing.InternalBenchmark{
-{{#each benchmarks}}
-        {"{{name}}", {{qualified_name}}},
-{{/each}}
-    }
+	var tests = []codspeed_testing.InternalTest{}
+	var fuzzTargets = []codspeed_testing.InternalFuzzTarget{}
+	var examples = []codspeed_testing.InternalExample{}
+	var benchmarks = []codspeed_testing.InternalBenchmark{
+		{{#each benchmarks}}
+		        {"{{name}}", {{qualified_name}}},
+		{{/each}}
+	}
 
-    m := codspeed_testing.MainStart(simpleDeps{}, tests, benchmarks, fuzzTargets, examples)
-    m.Run()
+	m := codspeed_testing.MainStart(TestDeps{}, tests, benchmarks, fuzzTargets, examples)
+	m.Run()
 }


### PR DESCRIPTION
- Renamed `simpleDeps` to `TestDeps` (like it's done in the `testing/internal/testdeps/deps.go` file)
- Add comment to clarify where this comes from
- Implement `MatchString` to be able to filter benchmarks 