### PR TITLE
fix(go-runner): resolve path using first URI part

### DIFF
--- a/go-runner/src/lib.rs
+++ b/go-runner/src/lib.rs
@@ -75,8 +75,14 @@ fn collect_walltime_results(bench_name_to_path: HashMap<String, PathBuf>) -> any
     let mut benchmarks_by_pid: HashMap<u32, Vec<results::walltime_results::WalltimeBenchmark>> =
         HashMap::new();
     for raw in raw_results {
+        // We only parse the `func Benchmark*` name which is the first part of the URI
+        let func_name = raw
+            .benchmark_name
+            .split("::")
+            .next()
+            .unwrap_or(&raw.benchmark_name);
         let file_path = bench_name_to_path
-            .get(&raw.benchmark_name)
+            .get(func_name)
             .map(|p| p.to_string_lossy().to_string());
         benchmarks_by_pid
             .entry(raw.pid)

--- a/go-runner/src/snapshots/go_runner__integration_tests__assert_results_snapshots@golang-benchmarks_1.snap
+++ b/go-runner/src/snapshots/go_runner__integration_tests__assert_results_snapshots@golang-benchmarks_1.snap
@@ -1,5 +1,5 @@
 ---
-source: src/integration_tests.rs
+source: go-runner/src/integration_tests.rs
 expression: content
 ---
 {
@@ -69,7 +69,7 @@ expression: content
     },
     {
       "name": "BenchmarkContainsMethods::Bytes.Contains",
-      "uri": "unknown::BenchmarkContainsMethods::Bytes.Contains",
+      "uri": "contains/contains_test.go::BenchmarkContainsMethods::Bytes.Contains",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -80,7 +80,7 @@ expression: content
     },
     {
       "name": "BenchmarkContainsMethods::RegexMatch",
-      "uri": "unknown::BenchmarkContainsMethods::RegexMatch",
+      "uri": "contains/contains_test.go::BenchmarkContainsMethods::RegexMatch",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -91,7 +91,7 @@ expression: content
     },
     {
       "name": "BenchmarkContainsMethods::RegexMatchString",
-      "uri": "unknown::BenchmarkContainsMethods::RegexMatchString",
+      "uri": "contains/contains_test.go::BenchmarkContainsMethods::RegexMatchString",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -102,7 +102,7 @@ expression: content
     },
     {
       "name": "BenchmarkContainsMethods::Strings.Contains",
-      "uri": "unknown::BenchmarkContainsMethods::Strings.Contains",
+      "uri": "contains/contains_test.go::BenchmarkContainsMethods::Strings.Contains",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,

--- a/go-runner/src/snapshots/go_runner__integration_tests__assert_results_snapshots@golang-benchmarks_2.snap
+++ b/go-runner/src/snapshots/go_runner__integration_tests__assert_results_snapshots@golang-benchmarks_2.snap
@@ -1,5 +1,5 @@
 ---
-source: src/integration_tests.rs
+source: go-runner/src/integration_tests.rs
 expression: content
 ---
 {
@@ -14,7 +14,7 @@ expression: content
   "benchmarks": [
     {
       "name": "BenchmarkConcat::Buffer",
-      "uri": "unknown::BenchmarkConcat::Buffer",
+      "uri": "concat/concat_test.go::BenchmarkConcat::Buffer",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -25,7 +25,7 @@ expression: content
     },
     {
       "name": "BenchmarkConcat::Builder",
-      "uri": "unknown::BenchmarkConcat::Builder",
+      "uri": "concat/concat_test.go::BenchmarkConcat::Builder",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -36,7 +36,7 @@ expression: content
     },
     {
       "name": "BenchmarkConcat::String",
-      "uri": "unknown::BenchmarkConcat::String",
+      "uri": "concat/concat_test.go::BenchmarkConcat::String",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,

--- a/go-runner/src/snapshots/go_runner__integration_tests__assert_results_snapshots@hugo_5.snap
+++ b/go-runner/src/snapshots/go_runner__integration_tests__assert_results_snapshots@hugo_5.snap
@@ -1,5 +1,5 @@
 ---
-source: src/integration_tests.rs
+source: go-runner/src/integration_tests.rs
 expression: content
 ---
 {
@@ -36,7 +36,7 @@ expression: content
     },
     {
       "name": "BenchmarkWhereOps::eq",
-      "uri": "unknown::BenchmarkWhereOps::eq",
+      "uri": "tpl/collections/where_test.go::BenchmarkWhereOps::eq",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -47,7 +47,7 @@ expression: content
     },
     {
       "name": "BenchmarkWhereOps::like",
-      "uri": "unknown::BenchmarkWhereOps::like",
+      "uri": "tpl/collections/where_test.go::BenchmarkWhereOps::like",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -58,7 +58,7 @@ expression: content
     },
     {
       "name": "BenchmarkWhereOps::ne",
-      "uri": "unknown::BenchmarkWhereOps::ne",
+      "uri": "tpl/collections/where_test.go::BenchmarkWhereOps::ne",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,

--- a/go-runner/src/snapshots/go_runner__integration_tests__assert_results_snapshots@hugo_6.snap
+++ b/go-runner/src/snapshots/go_runner__integration_tests__assert_results_snapshots@hugo_6.snap
@@ -1,5 +1,5 @@
 ---
-source: src/integration_tests.rs
+source: go-runner/src/integration_tests.rs
 expression: content
 ---
 {
@@ -14,7 +14,7 @@ expression: content
   "benchmarks": [
     {
       "name": "BenchmarkTruncate::Plain_text",
-      "uri": "unknown::BenchmarkTruncate::Plain_text",
+      "uri": "tpl/strings/truncate_test.go::BenchmarkTruncate::Plain_text",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -25,7 +25,7 @@ expression: content
     },
     {
       "name": "BenchmarkTruncate::With_link",
-      "uri": "unknown::BenchmarkTruncate::With_link",
+      "uri": "tpl/strings/truncate_test.go::BenchmarkTruncate::With_link",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,

--- a/go-runner/src/snapshots/go_runner__integration_tests__assert_results_snapshots@zerolog_0.snap
+++ b/go-runner/src/snapshots/go_runner__integration_tests__assert_results_snapshots@zerolog_0.snap
@@ -1,5 +1,5 @@
 ---
-source: src/integration_tests.rs
+source: go-runner/src/integration_tests.rs
 expression: content
 ---
 {
@@ -14,7 +14,7 @@ expression: content
   "benchmarks": [
     {
       "name": "BenchmarkAppendBytes::EncodingFirst",
-      "uri": "unknown::BenchmarkAppendBytes::EncodingFirst",
+      "uri": "internal/json/bytes_test.go::BenchmarkAppendBytes::EncodingFirst",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -25,7 +25,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendBytes::EncodingLast",
-      "uri": "unknown::BenchmarkAppendBytes::EncodingLast",
+      "uri": "internal/json/bytes_test.go::BenchmarkAppendBytes::EncodingLast",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -36,7 +36,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendBytes::EncodingMiddle",
-      "uri": "unknown::BenchmarkAppendBytes::EncodingMiddle",
+      "uri": "internal/json/bytes_test.go::BenchmarkAppendBytes::EncodingMiddle",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -47,7 +47,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendBytes::MultiBytesFirst",
-      "uri": "unknown::BenchmarkAppendBytes::MultiBytesFirst",
+      "uri": "internal/json/bytes_test.go::BenchmarkAppendBytes::MultiBytesFirst",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -58,7 +58,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendBytes::MultiBytesLast",
-      "uri": "unknown::BenchmarkAppendBytes::MultiBytesLast",
+      "uri": "internal/json/bytes_test.go::BenchmarkAppendBytes::MultiBytesLast",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -69,7 +69,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendBytes::MultiBytesMiddle",
-      "uri": "unknown::BenchmarkAppendBytes::MultiBytesMiddle",
+      "uri": "internal/json/bytes_test.go::BenchmarkAppendBytes::MultiBytesMiddle",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -80,7 +80,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendBytes::NoEncoding",
-      "uri": "unknown::BenchmarkAppendBytes::NoEncoding",
+      "uri": "internal/json/bytes_test.go::BenchmarkAppendBytes::NoEncoding",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -91,7 +91,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendString::EncodingFirst",
-      "uri": "unknown::BenchmarkAppendString::EncodingFirst",
+      "uri": "internal/json/string_test.go::BenchmarkAppendString::EncodingFirst",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -102,7 +102,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendString::EncodingLast",
-      "uri": "unknown::BenchmarkAppendString::EncodingLast",
+      "uri": "internal/json/string_test.go::BenchmarkAppendString::EncodingLast",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -113,7 +113,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendString::EncodingMiddle",
-      "uri": "unknown::BenchmarkAppendString::EncodingMiddle",
+      "uri": "internal/json/string_test.go::BenchmarkAppendString::EncodingMiddle",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -124,7 +124,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendString::MultiBytesFirst",
-      "uri": "unknown::BenchmarkAppendString::MultiBytesFirst",
+      "uri": "internal/json/string_test.go::BenchmarkAppendString::MultiBytesFirst",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -135,7 +135,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendString::MultiBytesLast",
-      "uri": "unknown::BenchmarkAppendString::MultiBytesLast",
+      "uri": "internal/json/string_test.go::BenchmarkAppendString::MultiBytesLast",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -146,7 +146,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendString::MultiBytesMiddle",
-      "uri": "unknown::BenchmarkAppendString::MultiBytesMiddle",
+      "uri": "internal/json/string_test.go::BenchmarkAppendString::MultiBytesMiddle",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -157,7 +157,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendString::NoEncoding",
-      "uri": "unknown::BenchmarkAppendString::NoEncoding",
+      "uri": "internal/json/string_test.go::BenchmarkAppendString::NoEncoding",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,

--- a/go-runner/src/snapshots/go_runner__integration_tests__assert_results_snapshots@zerolog_1.snap
+++ b/go-runner/src/snapshots/go_runner__integration_tests__assert_results_snapshots@zerolog_1.snap
@@ -1,5 +1,5 @@
 ---
-source: src/integration_tests.rs
+source: go-runner/src/integration_tests.rs
 expression: content
 ---
 {
@@ -14,7 +14,7 @@ expression: content
   "benchmarks": [
     {
       "name": "BenchmarkAppendFloat::Float32",
-      "uri": "unknown::BenchmarkAppendFloat::Float32",
+      "uri": "internal/cbor/types_test.go::BenchmarkAppendFloat::Float32",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -25,7 +25,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendFloat::Float64",
-      "uri": "unknown::BenchmarkAppendFloat::Float64",
+      "uri": "internal/cbor/types_test.go::BenchmarkAppendFloat::Float64",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -36,7 +36,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendInt::int-Negative",
-      "uri": "unknown::BenchmarkAppendInt::int-Negative",
+      "uri": "internal/cbor/types_test.go::BenchmarkAppendInt::int-Negative",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -47,7 +47,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendInt::int-Positive",
-      "uri": "unknown::BenchmarkAppendInt::int-Positive",
+      "uri": "internal/cbor/types_test.go::BenchmarkAppendInt::int-Positive",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -58,7 +58,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendInt::int16",
-      "uri": "unknown::BenchmarkAppendInt::int16",
+      "uri": "internal/cbor/types_test.go::BenchmarkAppendInt::int16",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -69,7 +69,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendInt::int32",
-      "uri": "unknown::BenchmarkAppendInt::int32",
+      "uri": "internal/cbor/types_test.go::BenchmarkAppendInt::int32",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -80,7 +80,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendInt::int64",
-      "uri": "unknown::BenchmarkAppendInt::int64",
+      "uri": "internal/cbor/types_test.go::BenchmarkAppendInt::int64",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -91,7 +91,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendInt::int8",
-      "uri": "unknown::BenchmarkAppendInt::int8",
+      "uri": "internal/cbor/types_test.go::BenchmarkAppendInt::int8",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -102,7 +102,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendInt::uint16",
-      "uri": "unknown::BenchmarkAppendInt::uint16",
+      "uri": "internal/cbor/types_test.go::BenchmarkAppendInt::uint16",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -113,7 +113,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendInt::uint32",
-      "uri": "unknown::BenchmarkAppendInt::uint32",
+      "uri": "internal/cbor/types_test.go::BenchmarkAppendInt::uint32",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -124,7 +124,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendInt::uint64",
-      "uri": "unknown::BenchmarkAppendInt::uint64",
+      "uri": "internal/cbor/types_test.go::BenchmarkAppendInt::uint64",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -135,7 +135,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendInt::uint8",
-      "uri": "unknown::BenchmarkAppendInt::uint8",
+      "uri": "internal/cbor/types_test.go::BenchmarkAppendInt::uint8",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -146,7 +146,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendString::EncodingFirst",
-      "uri": "unknown::BenchmarkAppendString::EncodingFirst",
+      "uri": "internal/json/string_test.go::BenchmarkAppendString::EncodingFirst",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -157,7 +157,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendString::EncodingLast",
-      "uri": "unknown::BenchmarkAppendString::EncodingLast",
+      "uri": "internal/json/string_test.go::BenchmarkAppendString::EncodingLast",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -168,7 +168,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendString::EncodingMiddle",
-      "uri": "unknown::BenchmarkAppendString::EncodingMiddle",
+      "uri": "internal/json/string_test.go::BenchmarkAppendString::EncodingMiddle",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -179,7 +179,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendString::MultiBytesFirst",
-      "uri": "unknown::BenchmarkAppendString::MultiBytesFirst",
+      "uri": "internal/json/string_test.go::BenchmarkAppendString::MultiBytesFirst",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -190,7 +190,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendString::MultiBytesLast",
-      "uri": "unknown::BenchmarkAppendString::MultiBytesLast",
+      "uri": "internal/json/string_test.go::BenchmarkAppendString::MultiBytesLast",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -201,7 +201,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendString::MultiBytesMiddle",
-      "uri": "unknown::BenchmarkAppendString::MultiBytesMiddle",
+      "uri": "internal/json/string_test.go::BenchmarkAppendString::MultiBytesMiddle",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -212,7 +212,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendString::NoEncoding",
-      "uri": "unknown::BenchmarkAppendString::NoEncoding",
+      "uri": "internal/json/string_test.go::BenchmarkAppendString::NoEncoding",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -223,7 +223,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendTime::Float",
-      "uri": "unknown::BenchmarkAppendTime::Float",
+      "uri": "internal/cbor/time_test.go::BenchmarkAppendTime::Float",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -234,7 +234,7 @@ expression: content
     },
     {
       "name": "BenchmarkAppendTime::Integer",
-      "uri": "unknown::BenchmarkAppendTime::Integer",
+      "uri": "internal/cbor/time_test.go::BenchmarkAppendTime::Integer",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,

--- a/go-runner/src/snapshots/go_runner__integration_tests__assert_results_snapshots@zerolog_2.snap
+++ b/go-runner/src/snapshots/go_runner__integration_tests__assert_results_snapshots@zerolog_2.snap
@@ -1,5 +1,5 @@
 ---
-source: src/integration_tests.rs
+source: go-runner/src/integration_tests.rs
 expression: content
 ---
 {
@@ -25,7 +25,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Bool",
-      "uri": "unknown::BenchmarkContextFieldType::Bool",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Bool",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -36,7 +36,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Bools",
-      "uri": "unknown::BenchmarkContextFieldType::Bools",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Bools",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -47,7 +47,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Ctx",
-      "uri": "unknown::BenchmarkContextFieldType::Ctx",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Ctx",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -58,7 +58,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Dur",
-      "uri": "unknown::BenchmarkContextFieldType::Dur",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Dur",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -69,7 +69,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Durs",
-      "uri": "unknown::BenchmarkContextFieldType::Durs",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Durs",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -80,7 +80,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Err",
-      "uri": "unknown::BenchmarkContextFieldType::Err",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Err",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -91,7 +91,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Errs",
-      "uri": "unknown::BenchmarkContextFieldType::Errs",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Errs",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -102,7 +102,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Float",
-      "uri": "unknown::BenchmarkContextFieldType::Float",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Float",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -113,7 +113,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Floats",
-      "uri": "unknown::BenchmarkContextFieldType::Floats",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Floats",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -124,7 +124,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Int",
-      "uri": "unknown::BenchmarkContextFieldType::Int",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Int",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -135,7 +135,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Interface",
-      "uri": "unknown::BenchmarkContextFieldType::Interface",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Interface",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -146,7 +146,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Interface(Object)",
-      "uri": "unknown::BenchmarkContextFieldType::Interface(Object)",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Interface(Object)",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -157,7 +157,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Interface(Objects)",
-      "uri": "unknown::BenchmarkContextFieldType::Interface(Objects)",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Interface(Objects)",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -168,7 +168,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Interfaces",
-      "uri": "unknown::BenchmarkContextFieldType::Interfaces",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Interfaces",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -179,7 +179,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Ints",
-      "uri": "unknown::BenchmarkContextFieldType::Ints",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Ints",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -190,7 +190,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Object",
-      "uri": "unknown::BenchmarkContextFieldType::Object",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Object",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -201,7 +201,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Str",
-      "uri": "unknown::BenchmarkContextFieldType::Str",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Str",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -212,7 +212,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Stringer",
-      "uri": "unknown::BenchmarkContextFieldType::Stringer",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Stringer",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -223,7 +223,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Strs",
-      "uri": "unknown::BenchmarkContextFieldType::Strs",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Strs",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -234,7 +234,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Time",
-      "uri": "unknown::BenchmarkContextFieldType::Time",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Time",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -245,7 +245,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Times",
-      "uri": "unknown::BenchmarkContextFieldType::Times",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Times",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -256,7 +256,7 @@ expression: content
     },
     {
       "name": "BenchmarkContextFieldType::Timestamp",
-      "uri": "unknown::BenchmarkContextFieldType::Timestamp",
+      "uri": "benchmark_test.go::BenchmarkContextFieldType::Timestamp",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -289,7 +289,7 @@ expression: content
     },
     {
       "name": "BenchmarkHooks::Nop/Multi",
-      "uri": "unknown::BenchmarkHooks::Nop/Multi",
+      "uri": "hook_test.go::BenchmarkHooks::Nop/Multi",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -300,7 +300,7 @@ expression: content
     },
     {
       "name": "BenchmarkHooks::Nop/Single",
-      "uri": "unknown::BenchmarkHooks::Nop/Single",
+      "uri": "hook_test.go::BenchmarkHooks::Nop/Single",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -311,7 +311,7 @@ expression: content
     },
     {
       "name": "BenchmarkHooks::Simple",
-      "uri": "unknown::BenchmarkHooks::Simple",
+      "uri": "hook_test.go::BenchmarkHooks::Simple",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -355,7 +355,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Bool",
-      "uri": "unknown::BenchmarkLogFieldType::Bool",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Bool",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -366,7 +366,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Bools",
-      "uri": "unknown::BenchmarkLogFieldType::Bools",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Bools",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -377,7 +377,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Ctx",
-      "uri": "unknown::BenchmarkLogFieldType::Ctx",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Ctx",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -388,7 +388,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Dur",
-      "uri": "unknown::BenchmarkLogFieldType::Dur",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Dur",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -399,7 +399,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Durs",
-      "uri": "unknown::BenchmarkLogFieldType::Durs",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Durs",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -410,7 +410,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Err",
-      "uri": "unknown::BenchmarkLogFieldType::Err",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Err",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -421,7 +421,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Errs",
-      "uri": "unknown::BenchmarkLogFieldType::Errs",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Errs",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -432,7 +432,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Float",
-      "uri": "unknown::BenchmarkLogFieldType::Float",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Float",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -443,7 +443,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Floats",
-      "uri": "unknown::BenchmarkLogFieldType::Floats",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Floats",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -454,7 +454,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Int",
-      "uri": "unknown::BenchmarkLogFieldType::Int",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Int",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -465,7 +465,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Interface",
-      "uri": "unknown::BenchmarkLogFieldType::Interface",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Interface",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -476,7 +476,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Interface(Object)",
-      "uri": "unknown::BenchmarkLogFieldType::Interface(Object)",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Interface(Object)",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -487,7 +487,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Interface(Objects)",
-      "uri": "unknown::BenchmarkLogFieldType::Interface(Objects)",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Interface(Objects)",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -498,7 +498,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Interfaces",
-      "uri": "unknown::BenchmarkLogFieldType::Interfaces",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Interfaces",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -509,7 +509,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Ints",
-      "uri": "unknown::BenchmarkLogFieldType::Ints",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Ints",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -520,7 +520,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Object",
-      "uri": "unknown::BenchmarkLogFieldType::Object",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Object",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -531,7 +531,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Str",
-      "uri": "unknown::BenchmarkLogFieldType::Str",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Str",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -542,7 +542,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Strs",
-      "uri": "unknown::BenchmarkLogFieldType::Strs",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Strs",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -553,7 +553,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Time",
-      "uri": "unknown::BenchmarkLogFieldType::Time",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Time",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -564,7 +564,7 @@ expression: content
     },
     {
       "name": "BenchmarkLogFieldType::Times",
-      "uri": "unknown::BenchmarkLogFieldType::Times",
+      "uri": "benchmark_test.go::BenchmarkLogFieldType::Times",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -586,7 +586,7 @@ expression: content
     },
     {
       "name": "BenchmarkSamplers::BasicSampler_0",
-      "uri": "unknown::BenchmarkSamplers::BasicSampler_0",
+      "uri": "sampler_test.go::BenchmarkSamplers::BasicSampler_0",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -597,7 +597,7 @@ expression: content
     },
     {
       "name": "BenchmarkSamplers::BasicSampler_1",
-      "uri": "unknown::BenchmarkSamplers::BasicSampler_1",
+      "uri": "sampler_test.go::BenchmarkSamplers::BasicSampler_1",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -608,7 +608,7 @@ expression: content
     },
     {
       "name": "BenchmarkSamplers::BasicSampler_5",
-      "uri": "unknown::BenchmarkSamplers::BasicSampler_5",
+      "uri": "sampler_test.go::BenchmarkSamplers::BasicSampler_5",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -619,7 +619,7 @@ expression: content
     },
     {
       "name": "BenchmarkSamplers::BurstSampler",
-      "uri": "unknown::BenchmarkSamplers::BurstSampler",
+      "uri": "sampler_test.go::BenchmarkSamplers::BurstSampler",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -630,7 +630,7 @@ expression: content
     },
     {
       "name": "BenchmarkSamplers::BurstSamplerNext",
-      "uri": "unknown::BenchmarkSamplers::BurstSamplerNext",
+      "uri": "sampler_test.go::BenchmarkSamplers::BurstSamplerNext",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -641,7 +641,7 @@ expression: content
     },
     {
       "name": "BenchmarkSamplers::BurstSampler_0",
-      "uri": "unknown::BenchmarkSamplers::BurstSampler_0",
+      "uri": "sampler_test.go::BenchmarkSamplers::BurstSampler_0",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -652,7 +652,7 @@ expression: content
     },
     {
       "name": "BenchmarkSamplers::RandomSampler",
-      "uri": "unknown::BenchmarkSamplers::RandomSampler",
+      "uri": "sampler_test.go::BenchmarkSamplers::RandomSampler",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -663,7 +663,7 @@ expression: content
     },
     {
       "name": "BenchmarkSamplers::RandomSampler_0",
-      "uri": "unknown::BenchmarkSamplers::RandomSampler_0",
+      "uri": "sampler_test.go::BenchmarkSamplers::RandomSampler_0",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,

--- a/go-runner/src/snapshots/go_runner__integration_tests__assert_results_snapshots@zerolog_3.snap
+++ b/go-runner/src/snapshots/go_runner__integration_tests__assert_results_snapshots@zerolog_3.snap
@@ -1,5 +1,5 @@
 ---
-source: src/integration_tests.rs
+source: go-runner/src/integration_tests.rs
 expression: content
 ---
 {
@@ -25,7 +25,7 @@ expression: content
     },
     {
       "name": "BenchmarkHandlers::Combined",
-      "uri": "unknown::BenchmarkHandlers::Combined",
+      "uri": "hlog/hlog_test.go::BenchmarkHandlers::Combined",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -36,7 +36,7 @@ expression: content
     },
     {
       "name": "BenchmarkHandlers::CombinedDisabled",
-      "uri": "unknown::BenchmarkHandlers::CombinedDisabled",
+      "uri": "hlog/hlog_test.go::BenchmarkHandlers::CombinedDisabled",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -47,7 +47,7 @@ expression: content
     },
     {
       "name": "BenchmarkHandlers::Single",
-      "uri": "unknown::BenchmarkHandlers::Single",
+      "uri": "hlog/hlog_test.go::BenchmarkHandlers::Single",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,
@@ -58,7 +58,7 @@ expression: content
     },
     {
       "name": "BenchmarkHandlers::SingleDisabled",
-      "uri": "unknown::BenchmarkHandlers::SingleDisabled",
+      "uri": "hlog/hlog_test.go::BenchmarkHandlers::SingleDisabled",
       "config": {
         "warmup_time_ns": null,
         "min_round_time_ns": null,


### PR DESCRIPTION
We create the URI like this: `BenchmarkContainsMethods::Bytes.Contains`, but we only have access to the parsed function name `BenchmarkContainsMethods`, so we have to match only part of it.